### PR TITLE
Add support for hostNetwork override

### DIFF
--- a/charts/cadvisor/Chart.yaml
+++ b/charts/cadvisor/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A chart for a Cadvisor deployment
 name: cadvisor
-version: 1.1.2
+version: 1.1.3
 appVersion: 0.36.0
 home: https://github.com/google/cadvisor
 sources:

--- a/charts/cadvisor/templates/daemonset.yaml
+++ b/charts/cadvisor/templates/daemonset.yaml
@@ -25,6 +25,9 @@ spec:
         {{- end }}
     spec:
       serviceAccountName: {{ template "cadvisor.serviceAccountName" . }}
+      {{ if .Values.hostNetwork }} 
+      hostNetwork: true
+      {{- end }}
       containers:
       - name: {{ template "cadvisor.name" . }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/cadvisor/values.yaml
+++ b/charts/cadvisor/values.yaml
@@ -39,6 +39,9 @@ resources: {}
 
 podAnnotations: {}
 
+# sometimes errors are encountered when using the cpu load reader without being on the host network
+hostNetwork: false
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true


### PR DESCRIPTION
Without the `hostNetwork: true` property specified (even with the pod security policy created), I encounter the following error in cadvisor:
```
W0806 06:12:14.487690       1 container.go:399] Could not initialize cpu load reader for "/kubepods/kubepods/besteffort/pod03eb5349-2f05-4222-9c8c-c7dbd4831b27/45b43357aeb0f3238c11f46e0fe409c0f822b025c94326f07b05fd3b452e5e1f": failed to create a netlink based cpuload reader: failed to get netlink family id for task stats: netlink request failed with error errno 0
```

Further reading indicated that this method of doing cpu load reading requires being on the host network. However, the current cadvisor chart does not support this override so doing so was only possible with a manual `kubectl edit ds/cadvisor` command. This should add support for it in the helm deployment.