### PR TITLE
Add imagePullSecrets

### DIFF
--- a/charts/cadvisor/Chart.yaml
+++ b/charts/cadvisor/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A chart for a Cadvisor deployment
 name: cadvisor
-version: 1.1.3
+version: 1.1.4
 appVersion: 0.36.0
 home: https://github.com/google/cadvisor
 sources:

--- a/charts/cadvisor/README.md
+++ b/charts/cadvisor/README.md
@@ -1,6 +1,6 @@
-# cAdvisor
+# Cadvisor
 
-A chart for a cAdvisor deployment
+A chart for a Cadvisor deployment
 
 Learn more: [https://github.com/google/cadvisor](https://github.com/google/cadvisor)
 

--- a/charts/cadvisor/README.md
+++ b/charts/cadvisor/README.md
@@ -1,6 +1,6 @@
-# Cadvisor
+# cAdvisor
 
-A chart for a Cadvisor deployment
+A chart for a cAdvisor deployment
 
 Learn more: [https://github.com/google/cadvisor](https://github.com/google/cadvisor)
 

--- a/charts/cadvisor/README.md
+++ b/charts/cadvisor/README.md
@@ -46,6 +46,7 @@ The following table lists the configurable parameters of the Prometheus MSTeams 
 | `image.repository`         | container image repository                       | `k8s.gcr.io/cadvisor` |
 | `image.tag`                | container image tag                              | `v0.36.0`             |
 | `image.pullPolicy`         | container image pull policy                      | `IfNotPresent`        |
+| `image.pullSecrets`        | container image pull secrets                     | `[]`                  |
 | `nodeSelector`             | node labels for pod assignment                   | `{}`                  |
 | `tolerations`              | node tolerations for pod assignment              | `[]`                  |
 | `affinity`                 | node affinity for pod assignment                 | `{}`                  |

--- a/charts/cadvisor/templates/daemonset.yaml
+++ b/charts/cadvisor/templates/daemonset.yaml
@@ -24,6 +24,12 @@ spec:
         {{ $key }}: {{ $value | quote }}
         {{- end }}
     spec:
+      {{ if .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.image.pullSecrets }}
+      - name: {{ . }}
+      {{-end }}
+      {{-end }}
       serviceAccountName: {{ template "cadvisor.serviceAccountName" . }}
       {{ if .Values.hostNetwork }} 
       hostNetwork: true

--- a/charts/cadvisor/templates/daemonset.yaml
+++ b/charts/cadvisor/templates/daemonset.yaml
@@ -28,8 +28,8 @@ spec:
       imagePullSecrets:
       {{- range .Values.image.pullSecrets }}
       - name: {{ . }}
-      {{-end }}
-      {{-end }}
+      {{- end }}
+      {{- end }}
       serviceAccountName: {{ template "cadvisor.serviceAccountName" . }}
       {{ if .Values.hostNetwork }} 
       hostNetwork: true

--- a/charts/cadvisor/values.yaml
+++ b/charts/cadvisor/values.yaml
@@ -3,6 +3,11 @@ image:
   tag: v0.36.0
   pullPolicy: IfNotPresent
 
+  ## Reference to one or more secrets to be used when pulling images
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ##
+  pullSecrets: []
+
 container:
   port: 8080
   additionalArgs:


### PR DESCRIPTION
Allows to reference to one or more secrets to be used when pulling images
ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/