### PR TITLE
Add values to enable metric relabeling to ServiceMonitor

### DIFF
--- a/charts/cadvisor/Chart.yaml
+++ b/charts/cadvisor/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A chart for a Cadvisor deployment
 name: cadvisor
-version: 1.2.2
+version: 1.2.3
 appVersion: 0.38.6
 home: https://github.com/google/cadvisor
 sources:

--- a/charts/cadvisor/README.md
+++ b/charts/cadvisor/README.md
@@ -60,6 +60,7 @@ The following table lists the configurable parameters of the cAdvisor chart and 
 | `podSecurityPolicy.create`     | create a own PodSecurityPolicy for the pod       | `false`                    |
 | `podSecurityPolicy.privileged` | create the PodSecurityPolicy as privileged       | `false`                    |
 | `metrics.enabled`              | create ServiceMonitor CR for Prometheus operator | `false`                    |
+| `metrics.relabeling`           | add relabeling configuration to ServiceMonitor   | `[]`                       |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/charts/cadvisor/README.md
+++ b/charts/cadvisor/README.md
@@ -1,6 +1,6 @@
-# Cadvisor
+# cAdvisor
 
-A chart for a Cadvisor deployment
+A chart for a cAdvisor deployment
 
 Learn more: [https://github.com/google/cadvisor](https://github.com/google/cadvisor)
 
@@ -26,7 +26,7 @@ To install the chart with the release name `my-release`:
 $ helm install --name my-release ckotzbauer/cadvisor
 ```
 
-The command deploys the Cadvisor on the Kubernetes cluster using the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+The command deploys cAdvisor on the Kubernetes cluster using the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
 
 ## Uninstalling the Chart
 
@@ -39,7 +39,7 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Configuration
 
-The following table lists the configurable parameters of the Prometheus MSTeams chart and their default values.
+The following table lists the configurable parameters of the cAdvisor chart and their default values.
 
 | Parameter                      | Description                                      | Default                    |
 | ------------------------------ | ------------------------------------------------ | -------------------------- |

--- a/charts/cadvisor/templates/servicemonitor.yaml
+++ b/charts/cadvisor/templates/servicemonitor.yaml
@@ -19,4 +19,8 @@ spec:
   endpoints:
     - path: /metrics
       port: http
+      {{- if .Values.metrics.relabelings }}
+      metricRelabelings:
+        {{- toYaml .Values.metrics.relabelings | nindent 8 }}
+      {{- end -}}
 {{- end -}}

--- a/charts/cadvisor/values.yaml
+++ b/charts/cadvisor/values.yaml
@@ -67,3 +67,16 @@ affinity: {}
 # This will create a ServiceMonitor Custom Resource indicating the prometheus operator what to scrape.
 metrics:
   enabled: false
+  # This will allow you to specify relabelings on the metrics. E.g. to use the kubernetes monitoring
+  # mixin with this chart set metrics.enabled above to true and use:
+  # relabelings:
+  #  - sourceLabels:
+  #    - name
+  #    targetLabel: container
+  #  - sourceLabels:
+  #    - container_label_io_kubernetes_pod_namespace
+  #    targetLabel: namespace
+  #  - sourceLabels:
+  #    - container_label_io_kubernetes_pod_name
+  #    targetLabel: pod
+  relabelings: []


### PR DESCRIPTION
This PR extends the ServiceMonitor template to allow for specification of metric relabelings which are required e.g. to use the kubernetes monitoring mixin, as this expects labels like "namespace", "pod" etc. to contain the appropriate values of the pod, namespace etc. the metrics actually belong to instead of the labels of the cAdvisor pod.

Also documented the required options for the mixin in values.yaml.

Additionally this incorporates the README.md changes from PR#48, because "hanging" trivial PRs bother me ;-)

Changes are backwards compatible, so just a bump in the patch version to 1.2.3.