### PR TITLE
cadvisor: support pre-scrape relabelings

### DIFF
--- a/charts/cadvisor/Chart.yaml
+++ b/charts/cadvisor/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A chart for a Cadvisor deployment
 name: cadvisor
-version: 1.4.0
+version: 2.0.0
 appVersion: 0.43.0
 home: https://github.com/google/cadvisor
 sources:

--- a/charts/cadvisor/README.md
+++ b/charts/cadvisor/README.md
@@ -28,6 +28,10 @@ $ helm install --name my-release ckotzbauer/cadvisor
 
 The command deploys cAdvisor on the Kubernetes cluster using the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
 
+## Upgrading from v1.x to v2.x
+
+- `metrics.relabelings` was renamed to `metrics.metricsRelabelings` to match the ServiceMonitor CRD naming
+
 ## Uninstalling the Chart
 
 To uninstall/delete the `my-release` deployment:
@@ -62,7 +66,8 @@ The following table lists the configurable parameters of the cAdvisor chart and 
 | `podSecurityContext.create`    | create the podSecurityContext in container spec  | `false`                    |
 | `podSecurityContext.privileged`| set podSecurityContext privileged to true        | `false`                    |
 | `metrics.enabled`              | create ServiceMonitor CR for Prometheus operator | `false`                    |
-| `metrics.relabeling`           | add relabeling configuration to ServiceMonitor   | `[]`                       |
+| `metrics.relabelings`          | add pre-scraping relabeling to ServiceMonitor    | `[]`                       |
+| `metrics.metricsRelabelings`   | add pre-ingestion relabeling to ServiceMonitor   | `[]`                       |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/charts/cadvisor/templates/servicemonitor.yaml
+++ b/charts/cadvisor/templates/servicemonitor.yaml
@@ -20,7 +20,11 @@ spec:
     - path: /metrics
       port: http
       {{- if .Values.metrics.relabelings }}
-      metricRelabelings:
+      relabelings:
         {{- toYaml .Values.metrics.relabelings | nindent 8 }}
+      {{- end -}}
+      {{- if .Values.metrics.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml .Values.metrics.metricRelabelings | nindent 8 }}
       {{- end -}}
 {{- end -}}

--- a/charts/cadvisor/values.yaml
+++ b/charts/cadvisor/values.yaml
@@ -72,7 +72,7 @@ affinity: {}
 # This will create a ServiceMonitor Custom Resource indicating the prometheus operator what to scrape.
 metrics:
   enabled: false
-  # This will allow you to specify relabelings on the metrics. E.g. to use the kubernetes monitoring
+  # This will allow you to specify relabelings on the metrics before ingestion. E.g. to use the kubernetes monitoring
   # mixin with this chart set metrics.enabled above to true and use:
   # relabelings:
   #  - sourceLabels:
@@ -84,4 +84,11 @@ metrics:
   #  - sourceLabels:
   #    - container_label_io_kubernetes_pod_name
   #    targetLabel: pod
+  metricRelabelings: []
+  # This will allow you to specify relabelings on the metrics before scraping.
+  # relabelings:
+  #  - action: replace
+  #    sourceLabels:
+  #    - __meta_kubernetes_pod_node_name
+  #    targetLabel: node
   relabelings: []


### PR DESCRIPTION
As per the [CRD](https://github.com/prometheus-operator/prometheus-operator/blob/36ec4099d12b06ea52823f4cfc6f4c054c730a87/jsonnet/prometheus-operator/servicemonitors-crd.json), this PR allows us to relabel metrics before scraping which gives us access to various useful labels such as node names.