### PR TITLE
Allow empty additonalLabels

### DIFF
--- a/charts/vulnerability-operator/Chart.yaml
+++ b/charts/vulnerability-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Scans SBOMs for vulnerabilities
 name: vulnerability-operator
-version: 0.13.0
+version: 0.13.1
 appVersion: 0.13.0
 home: https://github.com/ckotzbauer/vulnerability-operator
 sources:

--- a/charts/vulnerability-operator/templates/servicemonitor.yaml
+++ b/charts/vulnerability-operator/templates/servicemonitor.yaml
@@ -5,7 +5,9 @@ metadata:
   name: {{ template "app.name" . }}
   labels:
     {{- include "app.labels" . | nindent 4 }}
+    {{- if .Values.servicemonitor.additionalLabels }}
     {{- toYaml .Values.servicemonitor.additionalLabels | nindent 4 }}
+    {{- end -}}
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
# Allow empty additionalLabels

## Description

When `.Values.servicemonitor.enabled` is set to `true` and `.Values.servicemonitor.additionalLabels` is `{}`, helm fails to create the `ServiceMonitor`.

## Steps to reproduce

1. Set `.servicemonitor.enabled` to `true`
2. Set `.servicemonitor.additionalLabels` to `{}` (default)

## Expected result

The helm chart deploys and creates a `ServiceMonitor` resource.

## Actual result

Helm fails to template and resolves the `ServiceMonitor` resource to the following:

```yaml
---
# Source: vulnerability-operator/templates/servicemonitor.yaml

apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
metadata:
  name: vulnerability-operator
  labels:
    helm.sh/chart: vulnerability-operator-0.13.0
    app.kubernetes.io/name: vulnerability-operator
    app.kubernetes.io/instance: vuln-operator
    app.kubernetes.io/version: "0.13.0"
    app.kubernetes.io/managed-by: Helm
    {}
spec:
  selector:
    matchLabels:
      app.kubernetes.io/name: vulnerability-operator
      app.kubernetes.io/instance: vuln-operator
  namespaceSelector:
    matchNames:
      - default
  endpoints:
    - path: /metrics
      port: http
```

## Solution

Wrap `additionalLabels` in `if` block.