### PR TITLE
Update to cadvisor 0.47.0

### DIFF
--- a/charts/cadvisor/Chart.yaml
+++ b/charts/cadvisor/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: A chart for a Cadvisor deployment
 name: cadvisor
-version: 2.2.3
-appVersion: 0.44.0
+version: 2.2.4
+appVersion: 0.47.0
 home: https://github.com/google/cadvisor
 sources:
   - https://github.com/google/cadvisor

--- a/charts/cadvisor/values.yaml
+++ b/charts/cadvisor/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: gcr.io/cadvisor/cadvisor
-  tag: v0.44.0
+  tag: v0.47.0
   pullPolicy: IfNotPresent
 
   ## Reference to one or more secrets to be used when pulling images


### PR DESCRIPTION
This is specially useful as version 0.44.0 doesn't provide any arm64 container image yet. 

Signed-off-by: Roman Pertl <roman@pertl.org>