### PR TITLE
Allow to configure access mode of the host paths

### DIFF
--- a/charts/cadvisor/Chart.yaml
+++ b/charts/cadvisor/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A chart for a Cadvisor deployment
 name: cadvisor
-version: 2.3.0
+version: 2.3.1
 appVersion: 0.47.0
 home: https://github.com/google/cadvisor
 sources:

--- a/charts/cadvisor/README.md
+++ b/charts/cadvisor/README.md
@@ -89,3 +89,6 @@ $ helm install --name my-release -f values.yaml ckotzbauer/cadvisor
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
+
+## Centos, Fedora and RHEL
+You may need to run the container with additional configuration. Please see [this article](https://github.com/google/cadvisor/blob/master/docs/running.md#centos-fedora-and-rhel).

--- a/charts/cadvisor/templates/daemonset.yaml
+++ b/charts/cadvisor/templates/daemonset.yaml
@@ -53,7 +53,7 @@ spec:
         {{- range .Values.container.hostPaths }}
         - name: {{ .name }}
           mountPath: {{ default .path .mount }}
-          readOnly: true
+          readOnly: {{ list nil true | has .readOnly }}
         {{- end }}
         {{ if .Values.podSecurityContext.create }}
         securityContext:

--- a/charts/cadvisor/values.yaml
+++ b/charts/cadvisor/values.yaml
@@ -21,14 +21,19 @@ container:
     - name: rootfs
       path: "/"
       mount: "/rootfs"
+      readOnly: true
     - name: varrun
       path: "/var/run"
+      readOnly: true
     - name: sys
       path: "/sys"
+      readOnly: true
     - name: docker
       path: "/var/lib/docker"
+      readOnly: true
     - name: disk
       path: "/dev/disk"
+      readOnly: true
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
[CentOS, Fedora, and RHEL](https://github.com/google/cadvisor/blob/master/docs/running.md#centos-fedora-and-rhel) requires additional configuration for cAdvisor.

At this moment it's not possible to use this chart on RedHat 7 docker hosts due to next issue:
```bash
container create failed: time="2023-11-03T09:20:20+01:00" level=error msg="container_linux.go:380: starting container process caused: process_linux.go:545: container init caused: rootfs_linux.go:75: mounting \"/run/containers/storage/overlay-containers/b74f5f765af298c4fb611d3c2e460043d7279ba46d9df820461e5e27f6bedb2e/userdata/run/secrets\" to rootfs at \"/run/secrets\" caused: mkdir /var/lib/containers/storage/overlay/5d08e663a66a9abd46571a6fce3244e2b99767bd4f65127e88bc4e94134b07f3/merged/run/secrets: read-only file system"
```

To resolve this in official docs we have to bind /var/run with a read-write mode:
```
--volume=/var/run:/var/run:rw
```