### PR TITLE
fix: namespaced resources

### DIFF
--- a/charts/access-manager/templates/deployment.yaml
+++ b/charts/access-manager/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "app.name" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "app.name" . }}
     chart: {{ template "app.chart" . }}

--- a/charts/access-manager/templates/serviceaccount.yaml
+++ b/charts/access-manager/templates/serviceaccount.yaml
@@ -8,4 +8,5 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   name: {{ template "app.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/charts/chekr/templates/configmap.yaml
+++ b/charts/chekr/templates/configmap.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "chekr.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "chekr.labels" . | nindent 4 }}
 data:

--- a/charts/chekr/templates/cronjob.yaml
+++ b/charts/chekr/templates/cronjob.yaml
@@ -6,6 +6,7 @@ apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: {{ include "chekr.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "chekr.labels" . | nindent 4 }}
 spec:

--- a/charts/chekr/templates/deployment.yaml
+++ b/charts/chekr/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "chekr.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "chekr.labels" . | nindent 4 }}
 spec:

--- a/charts/chekr/templates/ingress.yaml
+++ b/charts/chekr/templates/ingress.yaml
@@ -16,6 +16,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "chekr.labels" . | nindent 4 }}
   {{- with .Values.webserver.ingress.annotations }}

--- a/charts/chekr/templates/persistentvolumeclaim.yaml
+++ b/charts/chekr/templates/persistentvolumeclaim.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "chekr.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "chekr.labels" . | nindent 4 }}
 spec:

--- a/charts/chekr/templates/service.yaml
+++ b/charts/chekr/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "chekr.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "chekr.labels" . | nindent 4 }}
 spec:

--- a/charts/chekr/templates/serviceaccount.yaml
+++ b/charts/chekr/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "chekr.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "chekr.labels" . | nindent 4 }}
   {{- with .Values.job.serviceAccount.annotations }}

--- a/charts/postgres-operator/templates/pod-env-configmap.yaml
+++ b/charts/postgres-operator/templates/pod-env-configmap.yaml
@@ -7,5 +7,6 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
   name: {{ template "postgres-operator.fullname" . }}-env
+  namespace: {{ .Release.Namespace }}
 data:
 {{ toYaml .Values.pod_environment_config | indent 2 }}

--- a/charts/sbom-operator/templates/deployment.yaml
+++ b/charts/sbom-operator/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "app.name" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "app.labels" . | nindent 4 }}
 spec:

--- a/charts/sbom-operator/templates/serviceaccount.yaml
+++ b/charts/sbom-operator/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "app.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "app.labels" . | nindent 4 }}
 {{- end -}}

--- a/charts/vulnerability-operator/templates/deployment.yaml
+++ b/charts/vulnerability-operator/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "app.name" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "app.labels" . | nindent 4 }}
 spec:

--- a/charts/vulnerability-operator/templates/ingress.yaml
+++ b/charts/vulnerability-operator/templates/ingress.yaml
@@ -15,6 +15,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "app.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}

--- a/charts/vulnerability-operator/templates/service.yaml
+++ b/charts/vulnerability-operator/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "app.name" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "app.labels" . | nindent 4 }}
 spec:

--- a/charts/vulnerability-operator/templates/serviceaccount.yaml
+++ b/charts/vulnerability-operator/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "app.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "app.labels" . | nindent 4 }}
 {{- end -}}

--- a/charts/vulnerability-operator/templates/servicemonitor.yaml
+++ b/charts/vulnerability-operator/templates/servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "app.name" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "app.labels" . | nindent 4 }}
     {{- if .Values.servicemonitor.additionalLabels }}


### PR DESCRIPTION
Many of the namespace-scoped resources did not specify the namespace of release in the resource metadata. This would cause things to break if the user fed a namespace other than `default` during the `helm install`. I went through and added `namespace: {{ .Release.Namespace }}` to the `metadata` section of all of the resources which are namespace-scoped resources in Kubernetes. All cluster-scoped resources were left alone.