### PR TITLE
feat: Add extraVolumeMounts to vulnerability-operator and sbom-operator

### DIFF
--- a/charts/sbom-operator/README.md
+++ b/charts/sbom-operator/README.md
@@ -47,6 +47,7 @@ The following table lists the configurable parameters of the sbom-operator chart
 | `serviceAccount.name`                  | Name of the ServiceAccount to use                 | null                                     |
 | `jobImageMode`                         | Whether or not a job-image is used.               | `false`                                  |
 | `extraVolumes`                         | Extra volumes (needed for GithubApp PK).          | `[]`                                     |
+| `extraVolumeMounts`                    | Extra volume mounts (useful for adding CAs)       | `[]`                                     |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/charts/sbom-operator/templates/deployment.yaml
+++ b/charts/sbom-operator/templates/deployment.yaml
@@ -74,6 +74,9 @@ spec:
               name: work
             - mountPath: /tmp
               name: tmp
+{{- if .Values.extraVolumeMounts }}
+{{- toYaml .Values.extraVolumeMounts  | nindent 12 }}
+{{- end }}
       volumes:
         - name: work
           emptyDir: {}

--- a/charts/sbom-operator/values.yaml
+++ b/charts/sbom-operator/values.yaml
@@ -53,3 +53,5 @@ tolerations: []
 affinity: {}
 
 extraVolumes: []
+
+extraVolumeMounts: []

--- a/charts/vulnerability-operator/README.md
+++ b/charts/vulnerability-operator/README.md
@@ -44,6 +44,7 @@ The following table lists the configurable parameters of the vulnerability-opera
 | `priorityClassName`                    | priority class name for the pod                   | `""`                                          |
 | `resources`                            | pod resource requests & limits                    | See [values.yaml](values.yaml)                |
 | `extraVolumes`                         | Extra volumes (needed for GithubApp PK).          | `[]`                                          |
+| `extraVolumeMounts`                    | Extra volume mounts (useful for adding CAs)       | `[]`                                          |
 | `securityContext`                      | container securityContext                         | See [values.yaml](values.yaml)                |
 | `serviceAccount.create`	             | Should we create a ServiceAccount	             | `true`                                        |
 | `serviceAccount.name`		             | Name of the ServiceAccount to use                 | null                                          |

--- a/charts/vulnerability-operator/templates/deployment.yaml
+++ b/charts/vulnerability-operator/templates/deployment.yaml
@@ -70,6 +70,9 @@ spec:
             - mountPath: /vuln
               name: grype
             {{- end }}
+{{- if .Values.extraVolumeMounts }}
+{{- toYaml .Values.extraVolumeMounts  | nindent 12 }}
+{{- end }}
       volumes:
         - name: work
           emptyDir: {}

--- a/charts/vulnerability-operator/values.yaml
+++ b/charts/vulnerability-operator/values.yaml
@@ -107,3 +107,5 @@ tolerations: []
 affinity: {}
 
 extraVolumes: []
+
+extraVolumeMounts: []


### PR DESCRIPTION
Adding extraVolumeMounts value to the configurations for sbom-operator and vulnerability-operator. This will allow the user to mount volumes within the container. The use case which drove this feature was the need to add a CA to the /etc/ssl/certs directory for a private git repo.