### PR TITLE
Add configmap target check

### DIFF
--- a/charts/sbom-operator/Chart.yaml
+++ b/charts/sbom-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Catalogue all images of a Kubernetes cluster to multiple targets with Syft
 name: sbom-operator
-version: 0.37.0
+version: 0.37.1
 appVersion: 0.36.0
 home: https://github.com/ckotzbauer/sbom-operator
 sources:

--- a/charts/sbom-operator/templates/clusterrole.yaml
+++ b/charts/sbom-operator/templates/clusterrole.yaml
@@ -18,7 +18,7 @@ rules:
   - secrets
   verbs:
   - get
-{{- if and .Values.args (hasKey .Values.args "targets") .Values.args.targets (contains "configmap" .Values.args.targets) }}
+{{- if and .Values.args (hasKey .Values.args "targets") .Values.args.targets (contains "configmap" (coalesce .Values.args.targets "")) }}
 - apiGroups:
   - ""
   resources:

--- a/charts/sbom-operator/templates/clusterrole.yaml
+++ b/charts/sbom-operator/templates/clusterrole.yaml
@@ -18,6 +18,7 @@ rules:
   - secrets
   verbs:
   - get
+{{- if and .Values.args (hasKey .Values.args "targets") .Values.args.targets (contains "configmap" .Values.args.targets) }}
 - apiGroups:
   - ""
   resources:
@@ -27,6 +28,7 @@ rules:
   - create
   - list
   - delete
+{{- end }}
 - apiGroups:
   - ""
   resources:

--- a/charts/sbom-operator/templates/clusterrole.yaml
+++ b/charts/sbom-operator/templates/clusterrole.yaml
@@ -18,7 +18,7 @@ rules:
   - secrets
   verbs:
   - get
-{{- if and .Values.args (hasKey .Values.args "targets") .Values.args.targets (contains "configmap" (coalesce .Values.args.targets "")) }}
+{{- if and .Values.args (hasKey .Values.args "targets") .Values.args.targets (contains "configmap" (coalesce .Values.args.targets "git")) }}
 - apiGroups:
   - ""
   resources:

--- a/charts/sbom-operator/values.yaml
+++ b/charts/sbom-operator/values.yaml
@@ -10,7 +10,7 @@ image:
 
 args: {}
 
-envVars: {}
+envVars: []
 
 jobImageMode: false
 


### PR DESCRIPTION
As discussed in https://github.com/ckotzbauer/helm-charts/issues/200

I implemented a check to only include permissions to configmaps if target includes configmap. This reduces permissions.