### PR TITLE
NodePort can be specified for ServiceResource.

### DIFF
--- a/charts/cadvisor/templates/service.yaml
+++ b/charts/cadvisor/templates/service.yaml
@@ -14,6 +14,9 @@ spec:
     port: {{ .Values.container.port }}
     targetPort: {{ .Values.container.port }}
     protocol: TCP
+    {{- with .Values.service.nodePort }}
+    nodePort: {{ . }}
+    {{- end }}
   selector:
     app: {{ template "cadvisor.name" . }}
-  type: ClusterIP
+  type: {{ .Values.service.type }}

--- a/charts/cadvisor/values.yaml
+++ b/charts/cadvisor/values.yaml
@@ -35,6 +35,10 @@ container:
       path: "/dev/disk"
       readOnly: true
 
+service:
+  type: ClusterIP
+  nodePort:  # If type is NodePort, specify the nodePort value. (30000-32767)
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
Hello.
Enabled to specify NodePort instead of only ClusterIP for ServiceResource. Because I want to get metrics from external Prometheus.
Check it 😄 