### PR TITLE
feat: update vulnerability-operator to 0.28.4

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -19,7 +19,9 @@ jobs:
         uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3.5
 
       - name: Setup Python
-        uses: ckotzbauer/actions-toolkit/setup-python@187b42cc2ca9bc9257d6e72bb1c1be730f1d0565 # 0.56.0
+        uses: actions/setup-python@28f2168f4d98ee0445e3c6321f6e6616c83dd5ec
+        with:
+          python-version: '3.13'
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f # v2.8.0

--- a/charts/vulnerability-operator/Chart.yaml
+++ b/charts/vulnerability-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: Scans SBOMs for vulnerabilities
 name: vulnerability-operator
-version: 0.31.2
-appVersion: 0.28.3
+version: 0.31.3
+appVersion: 0.28.4
 home: https://github.com/ckotzbauer/vulnerability-operator
 sources:
   - https://github.com/ckotzbauer/vulnerability-operator

--- a/charts/vulnerability-operator/README.md
+++ b/charts/vulnerability-operator/README.md
@@ -31,7 +31,7 @@ The following table lists the configurable parameters of the vulnerability-opera
 | Parameter                          | Description                                                               | Default                                     |
 | ---------------------------------- | ------------------------------------------------------------------------- | ------------------------------------------- |
 | `image.repository`                 | container image repository                                                | `ghcr.io/ckotzbauer/vulnerability-operator` |
-| `image.tag`                        | container image tag                                                       | `0.28.3`                                    |
+| `image.tag`                        | container image tag                                                       | `0.28.4`                                    |
 | `image.pullPolicy`                 | container image pull policy                                               | `IfNotPresent`                              |
 | `args`                             | argument object for cli-args                                              | `{}`                                        |
 | `envVars`                          | environment variables                                                     | `{}`                                        |

--- a/charts/vulnerability-operator/templates/deployment.yaml
+++ b/charts/vulnerability-operator/templates/deployment.yaml
@@ -48,11 +48,17 @@ spec:
             name: http
             protocol: TCP
           livenessProbe:
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds | default 10 }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds | default 10 }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold | default 6 }}
             timeoutSeconds: 3
             httpGet:
               path: "/health"
               port: http
           readinessProbe:
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds | default 10 }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds | default 10 }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold | default 6 }}
             timeoutSeconds: 3
             httpGet:
               path: "/health"

--- a/charts/vulnerability-operator/values.yaml
+++ b/charts/vulnerability-operator/values.yaml
@@ -74,6 +74,16 @@ securityContext:
   seccompProfile:
     type: RuntimeDefault
 
+probes:
+  liveness:
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    failureThreshold: 6
+  readiness:
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    failureThreshold: 6
+
 serviceAccount:
   # Specifies whether a ServiceAccount should be created
   create: true

--- a/charts/vulnerability-operator/values.yaml
+++ b/charts/vulnerability-operator/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: ghcr.io/ckotzbauer/vulnerability-operator
-  tag: "0.28.3@sha256:7388f3da18ba00159e2b94794f3d0503267712fd13de51c9da3f4f0198cbfb23"
+  tag: "0.28.4@sha256:6fb298f14fba2f90cdfa8120f37de7c1c9b4d8e384b7544b3a97ad8dc4a0f165"
   pullPolicy: IfNotPresent
   pullSecrets: []
 


### PR DESCRIPTION
Automated chart bump triggered by upstream release.

- **Chart:** vulnerability-operator
- **New appVersion:** 0.28.4
- **New chart version:** 0.31.3
- **Image digest:** `sha256:6fb298f14fba2f90cdfa8120f37de7c1c9b4d8e384b7544b3a97ad8dc4a0f165`