### PR TITLE
feat: update sbom-operator to 0.42.0

### DIFF
--- a/charts/sbom-operator/Chart.yaml
+++ b/charts/sbom-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: Catalogue all images of a Kubernetes cluster to multiple targets with Syft
 name: sbom-operator
-version: 0.42.6
-appVersion: 0.41.5
+version: 0.43.0
+appVersion: 0.42.0
 home: https://github.com/ckotzbauer/sbom-operator
 sources:
   - https://github.com/ckotzbauer/sbom-operator

--- a/charts/sbom-operator/README.md
+++ b/charts/sbom-operator/README.md
@@ -31,7 +31,7 @@ The following table lists the configurable parameters of the sbom-operator chart
 | Parameter               | Description                              | Default                            |
 | ----------------------- | ---------------------------------------- | ---------------------------------- |
 | `image.repository`      | container image repository               | `ghcr.io/ckotzbauer/sbom-operator` |
-| `image.tag`                        | container image tag                                                       | `0.41.5`                                    |
+| `image.tag`                        | container image tag                                                       | `0.42.0`                                    |
 | `image.pullPolicy`      | container image pull policy              | `IfNotPresent`                     |
 | `image.pullSecrets`     | image pull-secrets                       | `[]`                               |
 | `args`                  | argument object for cli-args             | `{}`                               |

--- a/charts/sbom-operator/values.yaml
+++ b/charts/sbom-operator/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: ghcr.io/ckotzbauer/sbom-operator
-  tag: "0.41.5@sha256:9054fb3ab1cf38f12777697fc0ffacd8c42027e4dfb9da444da3fa2a531b266f"
+  tag: "0.42.0@sha256:9dfc8b87c0dfd99b808461f3517097b2a7b8b5ff0b53c3b7753e381bbc452075"
   pullPolicy: IfNotPresent
   pullSecrets: []
 


### PR DESCRIPTION
Automated chart bump triggered by upstream release.

- **Chart:** sbom-operator
- **New appVersion:** 0.42.0
- **New chart version:** 0.43.0
- **Image digest:** `sha256:9dfc8b87c0dfd99b808461f3517097b2a7b8b5ff0b53c3b7753e381bbc452075`