### PR TITLE
feat: update vulnerability-operator to 0.28.7

### DIFF
--- a/charts/vulnerability-operator/Chart.yaml
+++ b/charts/vulnerability-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: Scans SBOMs for vulnerabilities
 name: vulnerability-operator
-version: 0.31.5
-appVersion: 0.28.6
+version: 0.31.6
+appVersion: 0.28.7
 home: https://github.com/ckotzbauer/vulnerability-operator
 sources:
   - https://github.com/ckotzbauer/vulnerability-operator

--- a/charts/vulnerability-operator/README.md
+++ b/charts/vulnerability-operator/README.md
@@ -31,7 +31,7 @@ The following table lists the configurable parameters of the vulnerability-opera
 | Parameter                          | Description                                                               | Default                                     |
 | ---------------------------------- | ------------------------------------------------------------------------- | ------------------------------------------- |
 | `image.repository`                 | container image repository                                                | `ghcr.io/ckotzbauer/vulnerability-operator` |
-| `image.tag`                        | container image tag                                                       | `0.28.6`                                    |
+| `image.tag`                        | container image tag                                                       | `0.28.7`                                    |
 | `image.pullPolicy`                 | container image pull policy                                               | `IfNotPresent`                              |
 | `args`                             | argument object for cli-args                                              | `{}`                                        |
 | `envVars`                          | environment variables                                                     | `{}`                                        |

--- a/charts/vulnerability-operator/values.yaml
+++ b/charts/vulnerability-operator/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: ghcr.io/ckotzbauer/vulnerability-operator
-  tag: "0.28.6@sha256:826093d55c64293885c43b8406630d910ce251754620d447932651339955b07d"
+  tag: "0.28.7@sha256:a9d075b9dd3935ecfcdd93818c9b68b96c4a673e2b5c62a6cda4a6be6b13788e"
   pullPolicy: IfNotPresent
   pullSecrets: []
 


### PR DESCRIPTION
Automated chart bump triggered by upstream release.

- **Chart:** vulnerability-operator
- **New appVersion:** 0.28.7
- **New chart version:** 0.31.6
- **Image digest:** `sha256:a9d075b9dd3935ecfcdd93818c9b68b96c4a673e2b5c62a6cda4a6be6b13788e`