### PR TITLE
fix(sbom-operator): swap suggested requests and limits

### DIFF
--- a/charts/sbom-operator/Chart.yaml
+++ b/charts/sbom-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Catalogue all images of a Kubernetes cluster to multiple targets with Syft
 name: sbom-operator
-version: 0.43.4
+version: 0.43.5
 appVersion: 0.42.4
 home: https://github.com/ckotzbauer/sbom-operator
 sources:

--- a/charts/sbom-operator/values.yaml
+++ b/charts/sbom-operator/values.yaml
@@ -20,11 +20,11 @@ priorityClassName: ""
 
 resources: {}
 #  requests:
-#    cpu: 500m
-#    memory: 1Gi
-#  limits:
 #    cpu: 100m
 #    memory: 100Mi
+#  limits:
+#    cpu: 500m
+#    memory: 1Gi
 
 podSecurityContext: {}
 


### PR DESCRIPTION
The configured resource requests were larger than the limits. Since requests define the minimum guaranteed resources, they must not exceed the limits. Swapped the values so the configuration is valid and can be used directly.