### PR TITLE
feat: update sbom-operator to 0.42.4

### DIFF
--- a/charts/sbom-operator/Chart.yaml
+++ b/charts/sbom-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: Catalogue all images of a Kubernetes cluster to multiple targets with Syft
 name: sbom-operator
-version: 0.43.3
-appVersion: 0.42.3
+version: 0.43.4
+appVersion: 0.42.4
 home: https://github.com/ckotzbauer/sbom-operator
 sources:
   - https://github.com/ckotzbauer/sbom-operator

--- a/charts/sbom-operator/README.md
+++ b/charts/sbom-operator/README.md
@@ -31,7 +31,7 @@ The following table lists the configurable parameters of the sbom-operator chart
 | Parameter               | Description                              | Default                            |
 | ----------------------- | ---------------------------------------- | ---------------------------------- |
 | `image.repository`      | container image repository               | `ghcr.io/ckotzbauer/sbom-operator` |
-| `image.tag`                        | container image tag                                                       | `0.42.3`                                    |
+| `image.tag`                        | container image tag                                                       | `0.42.4`                                    |
 | `image.pullPolicy`      | container image pull policy              | `IfNotPresent`                     |
 | `image.pullSecrets`     | image pull-secrets                       | `[]`                               |
 | `args`                  | argument object for cli-args             | `{}`                               |

--- a/charts/sbom-operator/values.yaml
+++ b/charts/sbom-operator/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: ghcr.io/ckotzbauer/sbom-operator
-  tag: "0.42.3@sha256:dc1e41a3d1678d5fa673441b3feb04a1d1acc055134aed33ac2ea81b76cb104f"
+  tag: "0.42.4@sha256:17c815f035126def2bcf5a6f52e6ea1253f6790f50a4b643bef0e68daf1cf2e7"
   pullPolicy: IfNotPresent
   pullSecrets: []
 


### PR DESCRIPTION
Automated chart bump triggered by upstream release.

- **Chart:** sbom-operator
- **New appVersion:** 0.42.4
- **New chart version:** 0.43.4
- **Image digest:** `sha256:17c815f035126def2bcf5a6f52e6ea1253f6790f50a4b643bef0e68daf1cf2e7`