### PR TITLE
feat: update sbom-operator to 0.42.5

### DIFF
--- a/charts/sbom-operator/Chart.yaml
+++ b/charts/sbom-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: Catalogue all images of a Kubernetes cluster to multiple targets with Syft
 name: sbom-operator
-version: 0.43.5
-appVersion: 0.42.4
+version: 0.43.6
+appVersion: 0.42.5
 home: https://github.com/ckotzbauer/sbom-operator
 sources:
   - https://github.com/ckotzbauer/sbom-operator

--- a/charts/sbom-operator/README.md
+++ b/charts/sbom-operator/README.md
@@ -31,7 +31,7 @@ The following table lists the configurable parameters of the sbom-operator chart
 | Parameter               | Description                              | Default                            |
 | ----------------------- | ---------------------------------------- | ---------------------------------- |
 | `image.repository`      | container image repository               | `ghcr.io/ckotzbauer/sbom-operator` |
-| `image.tag`                        | container image tag                                                       | `0.42.4`                                    |
+| `image.tag`                        | container image tag                                                       | `0.42.5`                                    |
 | `image.pullPolicy`      | container image pull policy              | `IfNotPresent`                     |
 | `image.pullSecrets`     | image pull-secrets                       | `[]`                               |
 | `args`                  | argument object for cli-args             | `{}`                               |

--- a/charts/sbom-operator/values.yaml
+++ b/charts/sbom-operator/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: ghcr.io/ckotzbauer/sbom-operator
-  tag: "0.42.4@sha256:17c815f035126def2bcf5a6f52e6ea1253f6790f50a4b643bef0e68daf1cf2e7"
+  tag: "0.42.5@sha256:a925488e6e0e7081db936bc264c978f4052a63e80e837c8b9b0b6f46e6056179"
   pullPolicy: IfNotPresent
   pullSecrets: []
 


### PR DESCRIPTION
Automated chart bump triggered by upstream release.

- **Chart:** sbom-operator
- **New appVersion:** 0.42.5
- **New chart version:** 0.43.6
- **Image digest:** `sha256:a925488e6e0e7081db936bc264c978f4052a63e80e837c8b9b0b6f46e6056179`