### PR TITLE
feat: update vulnerability-operator to 0.28.10

### DIFF
--- a/charts/vulnerability-operator/Chart.yaml
+++ b/charts/vulnerability-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: Scans SBOMs for vulnerabilities
 name: vulnerability-operator
-version: 0.31.8
-appVersion: 0.28.9
+version: 0.31.9
+appVersion: 0.28.10
 home: https://github.com/ckotzbauer/vulnerability-operator
 sources:
   - https://github.com/ckotzbauer/vulnerability-operator

--- a/charts/vulnerability-operator/README.md
+++ b/charts/vulnerability-operator/README.md
@@ -31,7 +31,7 @@ The following table lists the configurable parameters of the vulnerability-opera
 | Parameter                          | Description                                                               | Default                                     |
 | ---------------------------------- | ------------------------------------------------------------------------- | ------------------------------------------- |
 | `image.repository`                 | container image repository                                                | `ghcr.io/ckotzbauer/vulnerability-operator` |
-| `image.tag`                        | container image tag                                                       | `0.28.9`                                    |
+| `image.tag`                        | container image tag                                                       | `0.28.10`                                    |
 | `image.pullPolicy`                 | container image pull policy                                               | `IfNotPresent`                              |
 | `args`                             | argument object for cli-args                                              | `{}`                                        |
 | `envVars`                          | environment variables                                                     | `{}`                                        |

--- a/charts/vulnerability-operator/values.yaml
+++ b/charts/vulnerability-operator/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: ghcr.io/ckotzbauer/vulnerability-operator
-  tag: "0.28.9@sha256:006650a86ce8e6f2a7772c375184cf93ebf35984589f33597b2a4b5bd8498ad3"
+  tag: "0.28.10@sha256:c33ecd445dd3b276e79edf078f51a07a331d064539515d38ac347bf71e5a38b1"
   pullPolicy: IfNotPresent
   pullSecrets: []
 


### PR DESCRIPTION
Automated chart bump triggered by upstream release.

- **Chart:** vulnerability-operator
- **New appVersion:** 0.28.10
- **New chart version:** 0.31.9
- **Image digest:** `sha256:c33ecd445dd3b276e79edf078f51a07a331d064539515d38ac347bf71e5a38b1`