### PR TITLE
feat: update vulnerability-operator to 0.28.11

### DIFF
--- a/charts/vulnerability-operator/Chart.yaml
+++ b/charts/vulnerability-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: Scans SBOMs for vulnerabilities
 name: vulnerability-operator
-version: 0.31.9
-appVersion: 0.28.10
+version: 0.31.10
+appVersion: 0.28.11
 home: https://github.com/ckotzbauer/vulnerability-operator
 sources:
   - https://github.com/ckotzbauer/vulnerability-operator

--- a/charts/vulnerability-operator/README.md
+++ b/charts/vulnerability-operator/README.md
@@ -31,7 +31,7 @@ The following table lists the configurable parameters of the vulnerability-opera
 | Parameter                          | Description                                                               | Default                                     |
 | ---------------------------------- | ------------------------------------------------------------------------- | ------------------------------------------- |
 | `image.repository`                 | container image repository                                                | `ghcr.io/ckotzbauer/vulnerability-operator` |
-| `image.tag`                        | container image tag                                                       | `0.28.10`                                    |
+| `image.tag`                        | container image tag                                                       | `0.28.11`                                    |
 | `image.pullPolicy`                 | container image pull policy                                               | `IfNotPresent`                              |
 | `args`                             | argument object for cli-args                                              | `{}`                                        |
 | `envVars`                          | environment variables                                                     | `{}`                                        |

--- a/charts/vulnerability-operator/values.yaml
+++ b/charts/vulnerability-operator/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: ghcr.io/ckotzbauer/vulnerability-operator
-  tag: "0.28.10@sha256:c33ecd445dd3b276e79edf078f51a07a331d064539515d38ac347bf71e5a38b1"
+  tag: "0.28.11@sha256:800c49845629243a50b7cfc02b777d1230dbe5fc00c6952193f5ee4d7ded7026"
   pullPolicy: IfNotPresent
   pullSecrets: []
 


### PR DESCRIPTION
Automated chart bump triggered by upstream release.

- **Chart:** vulnerability-operator
- **New appVersion:** 0.28.11
- **New chart version:** 0.31.10
- **Image digest:** `sha256:800c49845629243a50b7cfc02b777d1230dbe5fc00c6952193f5ee4d7ded7026`