### PR TITLE
feat: update sbom-operator to 0.43.1

### DIFF
--- a/charts/sbom-operator/Chart.yaml
+++ b/charts/sbom-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: Catalogue all images of a Kubernetes cluster to multiple targets with Syft
 name: sbom-operator
-version: 0.44.0
-appVersion: 0.43.0
+version: 0.44.1
+appVersion: 0.43.1
 home: https://github.com/ckotzbauer/sbom-operator
 sources:
   - https://github.com/ckotzbauer/sbom-operator

--- a/charts/sbom-operator/README.md
+++ b/charts/sbom-operator/README.md
@@ -31,7 +31,7 @@ The following table lists the configurable parameters of the sbom-operator chart
 | Parameter               | Description                              | Default                            |
 | ----------------------- | ---------------------------------------- | ---------------------------------- |
 | `image.repository`      | container image repository               | `ghcr.io/ckotzbauer/sbom-operator` |
-| `image.tag`                        | container image tag                                                       | `0.43.0`                                    |
+| `image.tag`                        | container image tag                                                       | `0.43.1`                                    |
 | `image.pullPolicy`      | container image pull policy              | `IfNotPresent`                     |
 | `image.pullSecrets`     | image pull-secrets                       | `[]`                               |
 | `args`                  | argument object for cli-args             | `{}`                               |

--- a/charts/sbom-operator/values.yaml
+++ b/charts/sbom-operator/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: ghcr.io/ckotzbauer/sbom-operator
-  tag: "0.43.0@sha256:bbc5fa4b4c5376b6fb9e1e51608d92c39bd47f4406b565429f3a97b12122cc27"
+  tag: "0.43.1@sha256:2dd985ec9ed086db63a6d794c56a2e3d42006f8cff7b9c98e9c2b1dbe8dc2a4e"
   pullPolicy: IfNotPresent
   pullSecrets: []
 


### PR DESCRIPTION
Automated chart bump triggered by upstream release.

- **Chart:** sbom-operator
- **New appVersion:** 0.43.1
- **New chart version:** 0.44.1
- **Image digest:** `sha256:2dd985ec9ed086db63a6d794c56a2e3d42006f8cff7b9c98e9c2b1dbe8dc2a4e`