### PR TITLE
feat: update sbom-operator to 0.43.4

### DIFF
--- a/charts/sbom-operator/Chart.yaml
+++ b/charts/sbom-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: Catalogue all images of a Kubernetes cluster to multiple targets with Syft
 name: sbom-operator
-version: 0.44.3
-appVersion: 0.43.3
+version: 0.44.4
+appVersion: 0.43.4
 home: https://github.com/ckotzbauer/sbom-operator
 sources:
   - https://github.com/ckotzbauer/sbom-operator

--- a/charts/sbom-operator/README.md
+++ b/charts/sbom-operator/README.md
@@ -31,7 +31,7 @@ The following table lists the configurable parameters of the sbom-operator chart
 | Parameter               | Description                              | Default                            |
 | ----------------------- | ---------------------------------------- | ---------------------------------- |
 | `image.repository`      | container image repository               | `ghcr.io/ckotzbauer/sbom-operator` |
-| `image.tag`                        | container image tag                                                       | `0.43.3`                                    |
+| `image.tag`                        | container image tag                                                       | `0.43.4`                                    |
 | `image.pullPolicy`      | container image pull policy              | `IfNotPresent`                     |
 | `image.pullSecrets`     | image pull-secrets                       | `[]`                               |
 | `args`                  | argument object for cli-args             | `{}`                               |

--- a/charts/sbom-operator/values.yaml
+++ b/charts/sbom-operator/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: ghcr.io/ckotzbauer/sbom-operator
-  tag: "0.43.3@sha256:10e5295d433eeb613f49279a20a3e77841b2b9b22e5d96abf9b76fd811b20dc6"
+  tag: "0.43.4@sha256:b5c80e85c6390e593a1293d698c3e9ce7377710b32d2ce28a054df474ec60dd4"
   pullPolicy: IfNotPresent
   pullSecrets: []
 


### PR DESCRIPTION
Automated chart bump triggered by upstream release.

- **Chart:** sbom-operator
- **New appVersion:** 0.43.4
- **New chart version:** 0.44.4
- **Image digest:** `sha256:b5c80e85c6390e593a1293d698c3e9ce7377710b32d2ce28a054df474ec60dd4`