### PR TITLE
feat: update vulnerability-operator to 0.28.14

### DIFF
--- a/charts/vulnerability-operator/Chart.yaml
+++ b/charts/vulnerability-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: Scans SBOMs for vulnerabilities
 name: vulnerability-operator
-version: 0.31.12
-appVersion: 0.28.13
+version: 0.31.13
+appVersion: 0.28.14
 home: https://github.com/ckotzbauer/vulnerability-operator
 sources:
   - https://github.com/ckotzbauer/vulnerability-operator

--- a/charts/vulnerability-operator/README.md
+++ b/charts/vulnerability-operator/README.md
@@ -31,7 +31,7 @@ The following table lists the configurable parameters of the vulnerability-opera
 | Parameter                          | Description                                                               | Default                                     |
 | ---------------------------------- | ------------------------------------------------------------------------- | ------------------------------------------- |
 | `image.repository`                 | container image repository                                                | `ghcr.io/ckotzbauer/vulnerability-operator` |
-| `image.tag`                        | container image tag                                                       | `0.28.13`                                    |
+| `image.tag`                        | container image tag                                                       | `0.28.14`                                    |
 | `image.pullPolicy`                 | container image pull policy                                               | `IfNotPresent`                              |
 | `args`                             | argument object for cli-args                                              | `{}`                                        |
 | `envVars`                          | environment variables                                                     | `{}`                                        |

--- a/charts/vulnerability-operator/values.yaml
+++ b/charts/vulnerability-operator/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: ghcr.io/ckotzbauer/vulnerability-operator
-  tag: "0.28.13@sha256:5e6420930295736cb38384950d4e1d2fcfee565d7e8213fd5f832ef6a4596f08"
+  tag: "0.28.14@sha256:bad7b7b01df3fffc4c3814ec9613b4b422f89590eacb341c8fe42da54ec6aab4"
   pullPolicy: IfNotPresent
   pullSecrets: []
 


### PR DESCRIPTION
Automated chart bump triggered by upstream release.

- **Chart:** vulnerability-operator
- **New appVersion:** 0.28.14
- **New chart version:** 0.31.13
- **Image digest:** `sha256:bad7b7b01df3fffc4c3814ec9613b4b422f89590eacb341c8fe42da54ec6aab4`