### PR TITLE
feat: update sbom-operator to 0.43.6

### DIFF
--- a/charts/sbom-operator/Chart.yaml
+++ b/charts/sbom-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: Catalogue all images of a Kubernetes cluster to multiple targets with Syft
 name: sbom-operator
-version: 0.44.5
-appVersion: 0.43.5
+version: 0.44.6
+appVersion: 0.43.6
 home: https://github.com/ckotzbauer/sbom-operator
 sources:
   - https://github.com/ckotzbauer/sbom-operator

--- a/charts/sbom-operator/README.md
+++ b/charts/sbom-operator/README.md
@@ -31,7 +31,7 @@ The following table lists the configurable parameters of the sbom-operator chart
 | Parameter               | Description                              | Default                            |
 | ----------------------- | ---------------------------------------- | ---------------------------------- |
 | `image.repository`      | container image repository               | `ghcr.io/ckotzbauer/sbom-operator` |
-| `image.tag`                        | container image tag                                                       | `0.43.5`                                    |
+| `image.tag`                        | container image tag                                                       | `0.43.6`                                    |
 | `image.pullPolicy`      | container image pull policy              | `IfNotPresent`                     |
 | `image.pullSecrets`     | image pull-secrets                       | `[]`                               |
 | `args`                  | argument object for cli-args             | `{}`                               |

--- a/charts/sbom-operator/values.yaml
+++ b/charts/sbom-operator/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: ghcr.io/ckotzbauer/sbom-operator
-  tag: "0.43.5@sha256:1c7c5a97dba49ac56e8852ee55d17d9d5eff8242f0e2404301e1e8f99b4977f6"
+  tag: "0.43.6@sha256:117f47ad4883c184afd44f9111f58b386c8de271f5b5e9226008abe90a128e65"
   pullPolicy: IfNotPresent
   pullSecrets: []
 


### PR DESCRIPTION
Automated chart bump triggered by upstream release.

- **Chart:** sbom-operator
- **New appVersion:** 0.43.6
- **New chart version:** 0.44.6
- **Image digest:** `sha256:117f47ad4883c184afd44f9111f58b386c8de271f5b5e9226008abe90a128e65`