### PR TITLE
feat: update sbom-operator to 0.43.7

### DIFF
--- a/charts/sbom-operator/Chart.yaml
+++ b/charts/sbom-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: Catalogue all images of a Kubernetes cluster to multiple targets with Syft
 name: sbom-operator
-version: 0.44.6
-appVersion: 0.43.6
+version: 0.44.7
+appVersion: 0.43.7
 home: https://github.com/ckotzbauer/sbom-operator
 sources:
   - https://github.com/ckotzbauer/sbom-operator

--- a/charts/sbom-operator/README.md
+++ b/charts/sbom-operator/README.md
@@ -31,7 +31,7 @@ The following table lists the configurable parameters of the sbom-operator chart
 | Parameter               | Description                              | Default                            |
 | ----------------------- | ---------------------------------------- | ---------------------------------- |
 | `image.repository`      | container image repository               | `ghcr.io/ckotzbauer/sbom-operator` |
-| `image.tag`                        | container image tag                                                       | `0.43.6`                                    |
+| `image.tag`                        | container image tag                                                       | `0.43.7`                                    |
 | `image.pullPolicy`      | container image pull policy              | `IfNotPresent`                     |
 | `image.pullSecrets`     | image pull-secrets                       | `[]`                               |
 | `args`                  | argument object for cli-args             | `{}`                               |

--- a/charts/sbom-operator/values.yaml
+++ b/charts/sbom-operator/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: ghcr.io/ckotzbauer/sbom-operator
-  tag: "0.43.6@sha256:117f47ad4883c184afd44f9111f58b386c8de271f5b5e9226008abe90a128e65"
+  tag: "0.43.7@sha256:df5d76cd7b91568b57515563e310f927d948264d68135dbf94f89969463416dd"
   pullPolicy: IfNotPresent
   pullSecrets: []
 


### PR DESCRIPTION
Automated chart bump triggered by upstream release.

- **Chart:** sbom-operator
- **New appVersion:** 0.43.7
- **New chart version:** 0.44.7
- **Image digest:** `sha256:df5d76cd7b91568b57515563e310f927d948264d68135dbf94f89969463416dd`