### PR TITLE
feat: update sbom-operator to 0.44.3

### DIFF
--- a/charts/sbom-operator/Chart.yaml
+++ b/charts/sbom-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: Catalogue all images of a Kubernetes cluster to multiple targets with Syft
 name: sbom-operator
-version: 0.45.2
-appVersion: 0.44.2
+version: 0.45.3
+appVersion: 0.44.3
 home: https://github.com/ckotzbauer/sbom-operator
 sources:
   - https://github.com/ckotzbauer/sbom-operator

--- a/charts/sbom-operator/README.md
+++ b/charts/sbom-operator/README.md
@@ -31,7 +31,7 @@ The following table lists the configurable parameters of the sbom-operator chart
 | Parameter               | Description                              | Default                            |
 | ----------------------- | ---------------------------------------- | ---------------------------------- |
 | `image.repository`      | container image repository               | `ghcr.io/ckotzbauer/sbom-operator` |
-| `image.tag`                        | container image tag                                                       | `0.44.2`                                    |
+| `image.tag`                        | container image tag                                                       | `0.44.3`                                    |
 | `image.pullPolicy`      | container image pull policy              | `IfNotPresent`                     |
 | `image.pullSecrets`     | image pull-secrets                       | `[]`                               |
 | `args`                  | argument object for cli-args             | `{}`                               |

--- a/charts/sbom-operator/values.yaml
+++ b/charts/sbom-operator/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: ghcr.io/ckotzbauer/sbom-operator
-  tag: "0.44.2@sha256:2fc8d019a689a02783ab21483538642be9f9d6a938c386fa1a278a2d18d05f73"
+  tag: "0.44.3@sha256:08aa58f0eb5b629e4095852ffcaf4543e328eca2a7fd7e749393dc0d45ea144f"
   pullPolicy: IfNotPresent
   pullSecrets: []
 


### PR DESCRIPTION
Automated chart bump triggered by upstream release.

- **Chart:** sbom-operator
- **New appVersion:** 0.44.3
- **New chart version:** 0.45.3
- **Image digest:** `sha256:08aa58f0eb5b629e4095852ffcaf4543e328eca2a7fd7e749393dc0d45ea144f`