### PR TITLE
feat: update sbom-operator to 0.45.1

### DIFF
--- a/charts/sbom-operator/Chart.yaml
+++ b/charts/sbom-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: Catalogue all images of a Kubernetes cluster to multiple targets with Syft
 name: sbom-operator
-version: 0.46.0
-appVersion: 0.45.0
+version: 0.46.1
+appVersion: 0.45.1
 home: https://github.com/ckotzbauer/sbom-operator
 sources:
   - https://github.com/ckotzbauer/sbom-operator

--- a/charts/sbom-operator/README.md
+++ b/charts/sbom-operator/README.md
@@ -31,7 +31,7 @@ The following table lists the configurable parameters of the sbom-operator chart
 | Parameter               | Description                              | Default                            |
 | ----------------------- | ---------------------------------------- | ---------------------------------- |
 | `image.repository`      | container image repository               | `ghcr.io/ckotzbauer/sbom-operator` |
-| `image.tag`                        | container image tag                                                       | `0.45.0`                                    |
+| `image.tag`                        | container image tag                                                       | `0.45.1`                                    |
 | `image.pullPolicy`      | container image pull policy              | `IfNotPresent`                     |
 | `image.pullSecrets`     | image pull-secrets                       | `[]`                               |
 | `args`                  | argument object for cli-args             | `{}`                               |

--- a/charts/sbom-operator/values.yaml
+++ b/charts/sbom-operator/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: ghcr.io/ckotzbauer/sbom-operator
-  tag: "0.45.0@sha256:201af5ecb4638cdc84efdc41c17047afd478ee1c80ab9bd5f09146ef127e5e7b"
+  tag: "0.45.1@sha256:56740006cae7ab7b9daca38f0367caf3cbf20265ff692a2880c5138c733ad775"
   pullPolicy: IfNotPresent
   pullSecrets: []
 


### PR DESCRIPTION
Automated chart bump triggered by upstream release.

- **Chart:** sbom-operator
- **New appVersion:** 0.45.1
- **New chart version:** 0.46.1
- **Image digest:** `sha256:56740006cae7ab7b9daca38f0367caf3cbf20265ff692a2880c5138c733ad775`