### PR TITLE
feat: update sbom-operator to 0.45.2

### DIFF
--- a/charts/sbom-operator/Chart.yaml
+++ b/charts/sbom-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: Catalogue all images of a Kubernetes cluster to multiple targets with Syft
 name: sbom-operator
-version: 0.46.1
-appVersion: 0.45.1
+version: 0.46.2
+appVersion: 0.45.2
 home: https://github.com/ckotzbauer/sbom-operator
 sources:
   - https://github.com/ckotzbauer/sbom-operator

--- a/charts/sbom-operator/README.md
+++ b/charts/sbom-operator/README.md
@@ -31,7 +31,7 @@ The following table lists the configurable parameters of the sbom-operator chart
 | Parameter               | Description                              | Default                            |
 | ----------------------- | ---------------------------------------- | ---------------------------------- |
 | `image.repository`      | container image repository               | `ghcr.io/ckotzbauer/sbom-operator` |
-| `image.tag`                        | container image tag                                                       | `0.45.1`                                    |
+| `image.tag`                        | container image tag                                                       | `0.45.2`                                    |
 | `image.pullPolicy`      | container image pull policy              | `IfNotPresent`                     |
 | `image.pullSecrets`     | image pull-secrets                       | `[]`                               |
 | `args`                  | argument object for cli-args             | `{}`                               |

--- a/charts/sbom-operator/values.yaml
+++ b/charts/sbom-operator/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: ghcr.io/ckotzbauer/sbom-operator
-  tag: "0.45.1@sha256:56740006cae7ab7b9daca38f0367caf3cbf20265ff692a2880c5138c733ad775"
+  tag: "0.45.2@sha256:dbdb3e524deaf6d14b4ee4f4ffb8157fab13c4b1d7ef63b0b103f5f0f2e46551"
   pullPolicy: IfNotPresent
   pullSecrets: []
 


### PR DESCRIPTION
Automated chart bump triggered by upstream release.

- **Chart:** sbom-operator
- **New appVersion:** 0.45.2
- **New chart version:** 0.46.2
- **Image digest:** `sha256:dbdb3e524deaf6d14b4ee4f4ffb8157fab13c4b1d7ef63b0b103f5f0f2e46551`